### PR TITLE
Add support for buffer protocol (PEP 688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ For the purpose of determining breaking changes:
 
 [python-versions]: https://devguide.python.org/versions/#supported-versions
 
+## [Unreleased]
+
+[unreleased]: https://github.com/rogdham/bigxml/compare/v1.0.1...HEAD
+
+### :rocket: Added
+
+- Add support for buffer protocol ([PEP 688](https://peps.python.org/pep-0688/))
+
 ## [1.0.1] - 2024-04-27
 
 [1.0.1]: https://github.com/rogdham/bigxml/compare/v1.0.0...v1.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "defusedxml>=0.7.1",
-    "typing-extensions>=4.3.0 ; python_version<'3.10'",
+    "typing-extensions>=4.6.0 ; python_version<'3.12'",
 ]
 
 [project.urls]

--- a/src/bigxml/handle_mgr.py
+++ b/src/bigxml/handle_mgr.py
@@ -1,3 +1,4 @@
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,15 +21,13 @@ from bigxml.typing import (
 )
 from bigxml.utils import last_item_or_none
 
+if sys.version_info < (3, 11):  # pragma: no cover
+    from typing_extensions import Never
+else:  # pragma: no cover
+    from typing import Never
+
 if TYPE_CHECKING:
-    import sys
-
     from bigxml.nodes import XMLElement, XMLText
-
-    if sys.version_info < (3, 11):  # pragma: no cover
-        from typing import NoReturn as Never
-    else:  # pragma: no cover
-        from typing import Never
 
 
 class HandleMgr:

--- a/src/bigxml/stream.py
+++ b/src/bigxml/stream.py
@@ -1,17 +1,24 @@
 from io import IOBase
+import sys
 from typing import Any, Generator, Iterable, Optional, cast
 
 from bigxml.typing import Streamable, SupportsRead
 from bigxml.utils import autostart_generator
+
+if sys.version_info < (3, 12):  # pragma: no cover
+    from typing_extensions import Buffer
+else:  # pragma: no cover
+    from collections.abc import Buffer
 
 
 @autostart_generator
 def _flatten_stream(stream: Streamable) -> Generator[Optional[memoryview], int, None]:
     yield None
 
-    # bytes-like
+    # buffer protocol (bytes, etc.)
     try:
-        yield memoryview(cast(bytes, stream))
+        # we try-except instead of isinstance(stream, Buffer) for compatibility reasons
+        yield memoryview(cast(Buffer, stream))
         return  # noqa: TRY300
     except TypeError:
         pass

--- a/src/bigxml/typing.py
+++ b/src/bigxml/typing.py
@@ -16,6 +16,10 @@ if sys.version_info < (3, 10):  # pragma: no cover
 else:  # pragma: no cover
     from typing import ParamSpec
 
+if sys.version_info < (3, 12):  # pragma: no cover
+    from typing_extensions import Buffer
+else:  # pragma: no cover
+    from collections.abc import Buffer
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -30,7 +34,7 @@ class SupportsRead(Protocol[T_co]):
     def read(self, size: Optional[int] = None) -> T_co: ...  # pragma: no cover
 
 
-Streamable = Union[SupportsRead[bytes], bytes, Iterable["Streamable"]]
+Streamable = Union[Buffer, SupportsRead[bytes], Iterable["Streamable"]]
 
 
 class ClassHandlerWithCustomWrapper0(Protocol[T_co]):

--- a/tests/integration/test_typing.py
+++ b/tests/integration/test_typing.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import sys
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional, Tuple, Union
+from typing import Iterable, Iterator, Optional, Tuple, Union
 
 from bigxml import (
     HandlerTypeHelper,
@@ -12,16 +12,9 @@ from bigxml import (
 )
 
 if sys.version_info < (3, 11):
-    from typing import NoReturn as Never
+    from typing_extensions import Never, assert_type
 else:
-    from typing import Never
-
-if TYPE_CHECKING:
-    from typing_extensions import assert_type
-else:
-
-    def assert_type(val: Any, _: Any) -> Any:  # noqa: ANN401
-        return val
+    from typing import Never, assert_type
 
 
 # Note: the aim of this file is to test the typing of return-values


### PR DESCRIPTION
With [PEP 688](https://peps.python.org/pep-0688/) being accepted and included in Python 3.12, we should accept and test for custom classes implementing the buffer protocol being passed to `Parser`.

Moreover, static type checkers will stop promoting `bytearray`/`memoryview`/etc. to `bytes` at some point, so let's anticipate that (has been tested with custom version of mypy).

<details><summary>Mypy patch</summary>
<p>

```diff
diff --git a/mypy/options.py b/mypy/options.py
index 5ef6bc2a3..2642b6407 100644
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -375,8 +375,8 @@ class Options:
         # (undocumented feature).
         self.export_ref_info = False
 
-        self.disable_bytearray_promotion = False
-        self.disable_memoryview_promotion = False
+        self.disable_bytearray_promotion = True
+        self.disable_memoryview_promotion = True
         self.force_uppercase_builtins = False
         self.force_union_syntax = False
```

</p>
</details> 

<details><summary>Errors messages in current version with patched mypy</summary>
<p>

```
tests/unit/test_stream.py: note: In function "test_chain_types":
tests/unit/test_stream.py:107: error: Argument 2 to "StreamChain" has incompatible type "bytearray"; expected "Streamable"  [arg-type]
tests/unit/test_stream.py:107: note: Following member(s) of "bytearray" have conflicts:
tests/unit/test_stream.py:107: note:     Expected:
tests/unit/test_stream.py:107: note:         def __iter__(self) -> Iterator[Streamable]
tests/unit/test_stream.py:107: note:     Got:
tests/unit/test_stream.py:107: note:         def __iter__(self) -> Iterator[int]
tests/unit/test_stream.py:108: error: Argument 3 to "StreamChain" has incompatible type "memoryview"; expected "Streamable"  [arg-type]
tests/unit/test_stream.py:108: note: Following member(s) of "memoryview" have conflicts:
tests/unit/test_stream.py:108: note:     Expected:
tests/unit/test_stream.py:108: note:         def __iter__(self) -> Iterator[Streamable]
tests/unit/test_stream.py:108: note:     Got:
tests/unit/test_stream.py:108: note:         def __iter__(self) -> Iterator[int]
Found 2 errors in 1 file (checked 26 source files)
```


</p>
</details> 