### PR TITLE
Update license metadata (PEP 639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ For the purpose of determining breaking changes:
 
 [python-versions]: https://devguide.python.org/versions/#supported-versions
 
+## [Unreleased]
+
+[unreleased]: https://github.com/rogdham/bigxml/compare/v1.1.0...HEAD
+
+### :house: Internal
+
+- Update license metadata as per [PEP 639](https://peps.python.org/pep-0639)
+
 ## [1.1.0] - 2024-10-10
 
 [1.1.0]: https://github.com/rogdham/bigxml/compare/v1.0.1...v1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ authors = [{ name = "Rogdham", email = "contact@rogdham.net" }]
 description = "Pythonic xml parser to handle big files or streams"
 readme = { file = "README.md", content-type = "text/markdown" }
 keywords = ["xml", "parser", "big", "stream"]
-license.file = "LICENSE.txt"
+license = "MIT"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Removing from the classifiers may seem a bit early, but if it's good enough for projects such as `urllib3`, it's good enough for us.